### PR TITLE
Return since() fn from require(), instead of empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,10 @@ $ npm install jasmine2-custom-message --save-dev
 ```js
 require('jasmine2-custom-message');
 ```
+* or be explicit in any functional scope
+```js
+var since = require('jasmine2-custom-message');
+```
 
 ## Change log
 

--- a/jasmine2-custom-message.js
+++ b/jasmine2-custom-message.js
@@ -74,7 +74,7 @@
   };
 
   var defineSince = function() {
-    global.since = function(customMessage) {
+    return global.since = function(customMessage) {
       return {
         expect: wrapExpect(global.expect, customMessage)
       };


### PR DESCRIPTION
The line `module.exports = defineSince()` was returning `undefined`
because the function wasn't returning the `since()` function, it was
only assigning to `global.since`. This meant the module's value, when
required, was an empty object.

Returning the assignment allows both assigning to `global.since` and
returning the module's value via `require()`.