### PR TITLE
Correct output for toHaveBeenCalled matcher

### DIFF
--- a/jasmine2-custom-message.js
+++ b/jasmine2-custom-message.js
@@ -25,7 +25,19 @@
   };
 
   var formatString = function(data, message) {
-    message = message.replace(/#\{actual\}/g, data.actual);
+    if (
+      (
+        data.matcherName === "toHaveBeenCalled" ||
+        data.matcherName === "toHaveBeenCalledTimes"
+      ) &&
+      data.actual &&
+      data.actual.calls &&
+      typeof data.actual.calls.count === 'function'
+    ) {
+      message = message.replace(/#\{actual\}/g, data.actual.calls.count());
+    } else {
+      message = message.replace(/#\{actual\}/g, data.actual);
+    }
     message = message.replace(/#\{expected\}/g, data.expected);
     return message;
   };


### PR DESCRIPTION
I don't know if you want to add special cases for matchers, but these helped me.

```
since('we expect 3 calls, but got #{actual}').
  expect(myFnc).toHaveBeenCalledTimes(3);
```

Current output was:
`we expect 3 calls, but got undefined` 
After the PR we have: 
`we expect 3 calls, but got 4`
  