### PR TITLE
Adding "types" to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,5 +43,6 @@
     "error message",
     "failure message",
     "custom message"
-  ]
+  ],
+  "types": "./jasmine2-custom-message.d.ts"
 }


### PR DESCRIPTION
The "types" property tells TypeScript where to find the TypeScript declarations of "main".
See https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html