### PR TITLE
Copy expect() declarations from DefinitelyTyped

### DIFF
--- a/jasmine2-custom-message.d.ts
+++ b/jasmine2-custom-message.d.ts
@@ -3,6 +3,8 @@
 // Definitions by: Holger Jeromin <https://github.com/HolgerJeromin>
 // Definitions: https://github.com/avrelian/jasmine2-custom-message
 
+/// <reference types="jasmine" />
+
 interface Jasmine2CustomMessageFncParam {
     /** The actual value */
     actual: any,
@@ -10,31 +12,49 @@ interface Jasmine2CustomMessageFncParam {
     expected: any
 }
 
+interface ExpectWrapper {
+  /**
+   * Create an expectation for a spec.
+   * @param spy
+   */
+  expect(spy: Function): jasmine.Matchers<any>;
+
+  /**
+   * Create an expectation for a spec.
+   * @param actual
+   */
+  expect<T>(actual: ArrayLike<T>): jasmine.ArrayLikeMatchers<T>;
+
+  /**
+   * Create an expectation for a spec.
+   * @param actual Actual computed value to test expectations against.
+   */
+  expect<T>(actual: T): jasmine.Matchers<T>;
+
+  /**
+   * Create an expectation for a spec.
+   */
+  expect(): jasmine.NothingMatcher;
+}
+
 /**
  * Add a dynamic custom message.
  * The return value will be converted with toString()
  * If it is already a string #{actual} and #{expected} will be replaced with the current values.
  */
-declare function since(messageGenerator: (this: Jasmine2CustomMessageFncParam) => any): {
-    expect: (spyOrActual: Function | any) => jasmine.Matchers;
-}
+declare function since(messageGenerator: (this: Jasmine2CustomMessageFncParam) => any): ExpectWrapper;
 /**
  * Add a custom message.
  * #{actual} and #{expected} will be replaced with the current values.
  */
-declare function since(message: string): {
-    expect: (spyOrActual: Function | any)=> jasmine.Matchers;
-}
+declare function since(message: string): ExpectWrapper;
 /**
  * Add a static custom message.
  */
-declare function since(message: number | boolean): {
-    expect: (spyOrActual: Function | any) => jasmine.Matchers;
-}
+declare function since(message: number | boolean): ExpectWrapper;
+
 /**
  * Add a static custom message.
  * The text will be generated from toString() or JSON.stringify()
  */
-declare function since(message: any): {
-    expect: (spyOrActual: Function | any) => jasmine.Matchers;
-}
+declare function since(message: any): ExpectWrapper;


### PR DESCRIPTION
Copied all four `expect()` declarations from DefinitelyTyped into a `ExpectWrapper` interface.
Use this interface in all `since()` return types.

See https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/jasmine/index.d.ts#L75

Also added `<reference types="jasmine" />`, since this file references Jasmine types.