### PR TITLE
Issue #4 - allow original message to be included in the custom message

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,12 +52,17 @@ describe('test', function() {
 
 ## Powerful
 
-You can use expected and actual value of the assertion in your custom message, by:
+You can use expected and actual values of the assertion in your custom message by:
 
   * Passing a function, and using `this.actual` and `this.expected`
   * Passing a string, and using `#{actual}` and `#{expected}`
 
-#### Example using a function
+You can include the full original message from Jasmine by:
+
+  * Passing a function, and using `this.message`
+  * Passing a string, and using `#{message}`
+
+#### Examples using a function
 
 ```js
 describe('test', function() {
@@ -70,6 +75,20 @@ describe('test', function() {
 });
 ```
 
+```js
+describe('multiple tests that need some context added to the message', function() {
+    it('should be ok for all options', function() {
+      // passes the 1st loop iteration, fails the 2nd
+      [1, 2, 3, 4, 5].forEach(testOptionIndex => {
+        since(function() {
+          return 'for test option ' + testOptionIndex + ': ' + this.message;
+        }).
+        expect(testOptionIndex).toEqual(1); // => for test option 2: Expected 2 to equal 1.  
+      });
+    });
+});
+```
+
 #### Example using a string
 
 ```js
@@ -78,6 +97,18 @@ describe('test', function() {
     since('#{actual} =/= #{expected}').
     expect(3).toEqual(4); // => '3 =/= 4'
   });
+});
+```
+
+```js
+describe('multiple tests that need some context added to the message', function() {
+    it('should be ok for all options', function() {
+      // passes the 1st loop iteration, fails the 2nd
+      [1, 2, 3, 4, 5].forEach(testOptionIndex => {
+        since('for test option ' + testOptionIndex + ': #{message}').
+        expect(testOptionIndex).toEqual(1); // => for test option 2: Expected 2 to equal 1.  
+      });
+    });
 });
 ```
 

--- a/jasmine2-custom-message.js
+++ b/jasmine2-custom-message.js
@@ -39,6 +39,7 @@
       message = message.replace(/#\{actual\}/g, data.actual);
     }
     message = message.replace(/#\{expected\}/g, data.expected);
+    message = message.replace(/#\{message\}/g, data.message);
     return message;
   };
 

--- a/specs/common/test-jasmine2-custom-message.js
+++ b/specs/common/test-jasmine2-custom-message.js
@@ -56,6 +56,12 @@
                   expect(3).toEqual(2);
               });
 
+              it('containing #{actual}, #{expected}, and #{message} replacements', function() {
+                expectMessageToEqual("2 bla-bla-bla 3, that is, Expected 3 to equal 2.").
+                since('#{expected} bla-bla-bla #{actual}, that is, #{message}').
+                expect(3).toEqual(2);
+              });
+
             });
 
             it('number', function() {
@@ -83,12 +89,28 @@
                     expect(3).toEqual(2);
                 });
 
+                it('concatenating with expected, actual, and message properties', function() {
+                  expectMessageToEqual("2 bla-bla-bla 3, that is, Expected 3 to equal 2.").
+                  since(function() {
+                    return this.expected + ' bla-bla-bla ' + this.actual + ', that is, ' + this.message;
+                  }).
+                  expect(3).toEqual(2);
+                });
+
                 it('containing #{actual} and #{expected} replacements', function() {
                   expectMessageToEqual("2 bla-bla-bla 3").
                     since(function() {
                       return '#{expected} bla-bla-bla #{actual}';
                     }).
                     expect(3).toEqual(2);
+                });
+
+                it('containing #{actual}, #{expected}, and #{message} replacements', function() {
+                  expectMessageToEqual("2 bla-bla-bla 3, that is, Expected 3 to equal 2.").
+                  since(function() {
+                    return '#{expected} bla-bla-bla #{actual}, that is, #{message}';
+                  }).
+                  expect(3).toEqual(2);
                 });
 
               });

--- a/specs/protractor/test-jasmine2-custom-message.js
+++ b/specs/protractor/test-jasmine2-custom-message.js
@@ -38,6 +38,24 @@ require('../../jasmine2-custom-message');
                 expect(protractor.promise.fulfilled(3)).not.toEqual(3);
               });
 
+              describe('and original message is included', function() {
+                it('positively', function() {
+                  expectMessageToEqual("2 bla-bla-bla 3, that is, Expected 3 to equal 2.").
+                  since(function() {
+                    return this.expected + ' bla-bla-bla ' + this.actual + ', that is, ' + this.message;
+                  }).
+                  expect(protractor.promise.fulfilled(3)).toEqual(2);
+                });
+
+                it('negatively', function() {
+                  expectMessageToEqual("3 bla-bla-bla 3, that is, Expected 3 not to equal 3.").
+                  since(function() {
+                    return this.expected + ' bla-bla-bla ' + this.actual + ', that is, ' + this.message;
+                  }).
+                  expect(protractor.promise.fulfilled(3)).not.toEqual(3);
+                });
+              });
+
             });
 
             describe('and expected value is', function() {
@@ -62,6 +80,23 @@ require('../../jasmine2-custom-message');
                     expect(protractor.promise.fulfilled(3)).not.toEqual(protractor.promise.fulfilled(3));
                   });
 
+                  describe('and original message is included', function() {
+                    it('positively', function() {
+                      expectMessageToEqual("2 bla-bla-bla 3, that is, Expected 3 to equal 2.").
+                      since(function() {
+                        return this.expected + ' bla-bla-bla ' + this.actual + ', that is, ' + this.message;
+                      }).
+                      expect(protractor.promise.fulfilled(3)).toEqual(protractor.promise.fulfilled(2));
+                    });
+
+                    it('negatively', function() {
+                      expectMessageToEqual("3 bla-bla-bla 3, that is, Expected 3 not to equal 3.").
+                      since(function() {
+                        return this.expected + ' bla-bla-bla ' + this.actual + ', that is, ' + this.message;
+                      }).
+                      expect(protractor.promise.fulfilled(3)).not.toEqual(protractor.promise.fulfilled(3));
+                    });
+                  });
                 });
 
               });


### PR DESCRIPTION
Allow Jasmine's original failure message to be included in the custom message.

Within a function, use ```this.message```

Within a string, use ```#{message}```

Fixes Issue #4 