### PR TITLE
Made some updates to make npm test work on newer systems

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -27,8 +27,7 @@ module.exports = function(grunt) {
         options: {
           configFile: 'specs/protractor/conf.js',
           args: {
-            verbose: true,
-            includeStackTrace: false
+            verbose: true
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "node": ">= 0.8.0"
   },
   "scripts": {
-    "test": "grunt test"
+    "test": "grunt test",
+    "pretest": "webdriver-manager update"
   },
   "devDependencies": {
     "diff": "~1.0.8",
@@ -35,7 +36,7 @@
     "grunt": "~0.4.2",
     "grunt-contrib-jshint": "~0.6.0",
     "grunt-jasmine-node": "~0.1.0",
-    "grunt-protractor-runner": "^2.0.0",
+    "grunt-protractor-runner": "^5.0.0",
     "colors": "~1.1.2"
   },
   "keywords": [

--- a/specs/protractor/conf.js
+++ b/specs/protractor/conf.js
@@ -2,7 +2,6 @@ var colors = require('colors');
 colors.enabled = true;
 
 exports.config = {
-  seleniumAddress: 'http://localhost:4444/wd/hub',
   framework: 'jasmine2',
-  specs: ['../nodejs/jasmine2-custom-message.spec.js', './test-jasmine2-custom-message.js']
+  specs: ['../nodejs/jasmine2-custom-message.spec.js', './test-jasmine2-custom-message.js'],
 };


### PR DESCRIPTION
* Upgraded grunt-protractor, which updates protractor to 5.x
* Removed selenium address.  Use webdriver-manager, packaged with protractor, to start up selenium server.
* Add `webdriver-manager update` as a pretest step.  Perhaps this should be in the grunt file instead...
* Removed deprecated protractor option 'includeStackTrace'
