### PR TITLE
Make module work with webpack

### DIFF
--- a/jasmine2-custom-message.js
+++ b/jasmine2-custom-message.js
@@ -86,12 +86,14 @@
     };
   };
 
-  var defineSince = function() {
-    return global.since = function(customMessage) {
-      return {
-        expect: wrapExpect(global.expect, customMessage)
-      };
+  var since = function(customMessage) {
+    return {
+      expect: wrapExpect(global.expect, customMessage)
     };
+  };
+
+  var defineSince = function() {
+    return global.since = since;
   };
 
   if (isBrowserEnv) {

--- a/jasmine2-custom-message.js
+++ b/jasmine2-custom-message.js
@@ -92,12 +92,12 @@
     };
   };
 
-  if (isBrowserEnv) {
+  if (isCommonJS) {
+    global.since = since;
+    module.exports = since;
+  } else if (isBrowserEnv) {
     global.since = since
   } else {
-    if (isCommonJS) {
-      global.since = since;
-      module.exports = since;
-    }
+    // error: Could not initialize jasmine2-custom-message
   }
 })();

--- a/jasmine2-custom-message.js
+++ b/jasmine2-custom-message.js
@@ -92,15 +92,12 @@
     };
   };
 
-  var defineSince = function() {
-    return global.since = since;
-  };
-
   if (isBrowserEnv) {
-    defineSince();
+    global.since = since
   } else {
     if (isCommonJS) {
-      module.exports = defineSince();
+      global.since = since;
+      module.exports = since;
     }
   }
 })();


### PR DESCRIPTION
In my environment (webpack), both `isCommonJS` and `isBrowserEnv` is true. In this case, I need the commonjs behavior in order to use the plugin.

This PR prioritizes the commonjs branch over the browser branch in the case both are true.

The first two commits are cleanup to be able to understand the behavior better.